### PR TITLE
Fix broken meta tags for SEO and social media sharing

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <meta name="author" content="Microsoft Tech Community" />
         <meta name="robots" content="index, follow" />
         
-        <!-- Open Graph Meta Tags for Facebook andLinkedIn -->
+        <!-- Open Graph Meta Tags for Facebook and LinkedIn -->
         <meta property="og:type" content="website" />
         <meta property="og:url" content="https://staging-mtc.netlify.app/" />
         <meta property="og:title" content="Microsoft Tech Community - Learn. Code. Connect." />

--- a/index.html
+++ b/index.html
@@ -1,51 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <meta charset="UTF-8" />
-        <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Microsoft Tech Community</title>
+        <!-- Basic Meta Tags-->
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Your Website Title</title>
-
+        
+        <!-- Meta Tags for SEO -->
+        <title>Microsoft Tech Community - Learn. Code. Connect.</title>
+        <meta name="title" content="Microsoft Tech Community - Learn. Code. Connect." />
+        <meta name="description" content="A vibrant community of developers, designers, and innovators — led by students, for students. Join us for coding bootcamps, design jams, tech talks, and real-world projects." />
+        <meta name="keywords" content="Microsoft, tech community, coding, development, students, programming, technology, innovation, bootcamps, tech talks" />
+        <meta name="author" content="Microsoft Tech Community" />
+        <meta name="robots" content="index, follow" />
+        
+        <!-- Open Graph Meta Tags for Facebook andLinkedIn -->
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content="https://staging-mtc.netlify.app/" />
+        <meta property="og:title" content="Microsoft Tech Community - Learn. Code. Connect." />
+        <meta property="og:description" content="A vibrant community of developers, designers, and innovators — led by students, for students. Join us for coding bootcamps, design jams, tech talks, and real-world projects." />
+        <meta property="og:image" content="https://staging-mtc.netlify.app/images/image%2014.png" />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        <meta property="og:site_name" content="Microsoft Tech Community" />
+        
+        <!-- Twitter Card Meta Tags -->
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:url" content="https://staging-mtc.netlify.app/" />
+        <meta name="twitter:title" content="Microsoft Tech Community - Learn. Code. Connect." />
+        <meta name="twitter:description" content="A vibrant community of developers, designers, and innovators — led by students, for students. Join us for coding bootcamps, design jams, tech talks, and real-world projects." />
+        <meta name="twitter:image" content="https://staging-mtc.netlify.app/images/image%2014.png" />
+        
+        <!-- Favicon Links -->
         <link rel="icon" type="image/x-icon" href="/favicons/favicon.ico" />
-
-        <link
-            rel="icon"
-            type="image/png"
-            sizes="16x16"
-            href="/favicons/favicon-16x16.png"
-        />
-        <link
-            rel="icon"
-            type="image/png"
-            sizes="32x32"
-            href="/favicons/favicon-32x32.png"
-        />
-
-        <link
-            rel="apple-touch-icon"
-            sizes="180x180"
-            href="/favicons/apple-touch-icon.png"
-        />
-
-        <link
-            rel="icon"
-            type="image/png"
-            sizes="192x192"
-            href="/favicons/android-chrome-192x192.png"
-        />
-        <link
-            rel="icon"
-            type="image/png"
-            sizes="512x512"
-            href="/favicons/android-chrome-512x512.png"
-        />
-
+        <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png" />
+        <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png" />
+        <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png" />
+        <link rel="icon" type="image/png" sizes="192x192" href="/favicons/android-chrome-192x192.png" />
+        <link rel="icon" type="image/png" sizes="512x512" href="/favicons/android-chrome-512x512.png" />
         <link rel="manifest" href="/favicons/site.webmanifest" />
-
-        <meta name="theme-color" content="#ffffff" />
+        
+        <!-- Theme Colors -->
+        <meta name="theme-color" content="#0078d4" />
+        <meta name="msapplication-TileColor" content="#0078d4" />
     </head>
     <body>
         <div id="root"></div>

--- a/public/favicons/site.webmanifest
+++ b/public/favicons/site.webmanifest
@@ -1,1 +1,22 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+    "name": "Microsoft Tech Community",
+    "short_name": "MTC",
+    "description": "A vibrant community of developers, designers, and innovators — led by students, for students",
+    "icons": [
+        {
+            "src": "/favicons/android-chrome-192x192.png",
+            "sizes": "192x192",
+            "type": "image/png"
+        },
+        {
+            "src": "/favicons/android-chrome-512x512.png",
+            "sizes": "512x512",
+            "type": "image/png"
+        }
+    ],
+    "theme_color": "#0078d4",
+    "background_color": "#ffffff",
+    "display": "standalone",
+    "start_url": "/",
+    "scope": "/"
+}


### PR DESCRIPTION
Fixes #13

Fixed broken meta tags by:
- Added missing SEO meta tags (title, description, keywords)
- Added Open Graph tags for social media sharing
- Added Twitter Card support
- Removed duplicate meta tags
- Updated theme colour to Microsoft blue (#0078d4)

Files changed:
- index.html - Complete meta tags implementation
- public/favicons/site.webmanifest - Updated app info

